### PR TITLE
Support @Accessors annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,124 +7,141 @@ generated boilerplate code.
 
 Code __before__ applying the Lombok plugin:
 
-    package example.dto;
+```java
+package example.dto;
 
-    public class Contact {
-        private Long id;
+public class Contact {
+    private Long id;
 
-        private String firstName;
+    private String firstName;
 
-        private String lastName;
+    private String lastName;
 
-        private String phone;
+    private String phone;
 
-        private String email;
+    private String email;
 
-        public Long getId() {
-            return id;
-        }
-
-        public void setId(Long id) {
-            this.id = id;
-        }
-
-        public String getFirstName() {
-            return firstName;
-        }
-
-        public void setFirstName(String firstName) {
-            this.firstName = firstName;
-        }
-
-        public String getLastName() {
-            return lastName;
-        }
-
-        public void setLastName(String lastName) {
-            this.lastName = lastName;
-        }
-
-        public String getPhone() {
-            return phone;
-        }
-
-        public void setPhone(String phone) {
-            this.phone = phone;
-        }
-
-        public String getEmail() {
-            return email;
-        }
-
-        public void setEmail(String email) {
-            this.email = email;
-        }
+    public Long getId() {
+        return id;
     }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}
+```
 
 Code __after__ applying the Lombok plugin (much shorter):
 
-    package example.dto;
+```java
+package example.dto;
 
-    import lombok.Data;
+import lombok.Data;
 
-    @Data
-    public class Contact {
-        private Long id;
+@Data
+public class Contact {
+    private Long id;
 
-        private String firstName;
+    private String firstName;
 
-        private String lastName;
+    private String lastName;
 
-        private String phone;
+    private String phone;
 
-        private String email;
-    }
+    private String email;
+}
+```
 
 ## Using the plugin
 
 In your Maven pom.xml file, set up the MyBatis Generator plugin, and add
 mybatis-generator-lombok-plugin as a dependency:
 
-    <plugin>
-        <groupId>org.mybatis.generator</groupId>
-        <artifactId>mybatis-generator-maven-plugin</artifactId>
-        <version>${mybatis.generator.version}</version>
-        <configuration>
-            <overwrite>true</overwrite>
-        </configuration>
-        <dependencies>
-            <dependency>
-                <groupId>com.softwareloop</groupId>
-                <artifactId>mybatis-generator-lombok-plugin</artifactId>
-                <version>1.0</version>
-            </dependency>
-        </dependencies>
-    </plugin>
-
+```xml
+<plugin>
+    <groupId>org.mybatis.generator</groupId>
+    <artifactId>mybatis-generator-maven-plugin</artifactId>
+    <version>${mybatis.generator.version}</version>
+    <configuration>
+        <overwrite>true</overwrite>
+    </configuration>
+    <dependencies>
+        <dependency>
+            <groupId>com.softwareloop</groupId>
+            <artifactId>mybatis-generator-lombok-plugin</artifactId>
+            <version>1.0</version>
+        </dependency>
+    </dependencies>
+</plugin>
+```
 
 Then, in your MyBatis Generator configuration, include the plugin:
 
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE generatorConfiguration
-            PUBLIC "-//mybatis.org//DTD MyBatis Generator Configuration 1.0//EN"
-            "http://mybatis.org/dtd/mybatis-generator-config_1_0.dtd">
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE generatorConfiguration
+        PUBLIC "-//mybatis.org//DTD MyBatis Generator Configuration 1.0//EN"
+        "http://mybatis.org/dtd/mybatis-generator-config_1_0.dtd">
 
-    <generatorConfiguration>
-        <context id="example"
-                 targetRuntime="MyBatis3Simple"
-                 defaultModelType="flat">
-            <!-- include the plugin -->
-            <plugin type="com.softwareloop.mybatis.generator.plugins.LombokPlugin">
-                 <!-- enable annotations -->
-                 <property name="builder" value="true"/>
-                 <property name="allArgsConstructor" value="false"/>
-            </plugin>
+<generatorConfiguration>
+    <context id="example"
+             targetRuntime="MyBatis3Simple"
+             defaultModelType="flat">
+        <!-- include the plugin -->
+        <plugin type="com.softwareloop.mybatis.generator.plugins.LombokPlugin">
+             
+             <!-- enable annotations -->
+             <property name="builder" value="true"/>
+             <!-- annotation's option(boolean) -->
+             <property name="builder.fluent" value="true"/>
+             <!-- annotation's option(String) -->
+             <property name="builder.builderMethodName" value="myBuilder"/>
+             
+             <property name="accessors" value="true"/>
+             <!-- annotation's option(array of String) -->
+             <property name="accessors.prefix" value="m_, _"/>
+             
+             <!-- disable annotations -->
+             <property name="allArgsConstructor" value="false"/>
+        </plugin>
 
-            <!-- other configurations -->
+        <!-- other configurations -->
 
-        </context>
-    </generatorConfiguration>
-
+    </context>
+</generatorConfiguration>
+```
 
 ## Authors
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,14 @@
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
Added support for [@Accessors](https://projectlombok.org/features/experimental/Accessors) annotation.

Depends on this changes, we'll be able to specify annotation options as follows:

```xml
<plugin type="com.softwareloop.mybatis.generator.plugins.LombokPlugin">
     <property name="builder" value="true"/>
     <property name="builder.fluent" value="true"/> <!-- as boolean -->
     <property name="builder.buildMethodName" value="create"/> <!-- as String -->
     <property name="accessors" value="true"/>
     <property name="accessors.prefix" value="m_, _"/> <!-- as String[] -->
</plugin>
```