### PR TITLE
add mapper configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Then, in your MyBatis Generator configuration, include the plugin:
              
              <!-- disable annotations -->
              <property name="allArgsConstructor" value="false"/>
+             
+             <!-- disable @Mapper annotations -->
+             <property name="mapper" value="false"/>
         </plugin>
 
         <!-- other configurations -->

--- a/src/main/java/com/softwareloop/mybatis/generator/plugins/LombokPlugin.java
+++ b/src/main/java/com/softwareloop/mybatis/generator/plugins/LombokPlugin.java
@@ -21,6 +21,8 @@ public class LombokPlugin extends PluginAdapter {
 
     private final Collection<Annotations> annotations;
 
+    private final String MAPPER = "mapper";
+
     /**
      * LombokPlugin constructor
      */
@@ -189,9 +191,12 @@ public class LombokPlugin extends PluginAdapter {
             TopLevelClass topLevelClass,
             IntrospectedTable introspectedTable
     ) {
-        interfaze.addImportedType(new FullyQualifiedJavaType(
-                "org.apache.ibatis.annotations.Mapper"));
-        interfaze.addAnnotation("@Mapper");
+        String excludeMapper = this.properties.getProperty(MAPPER, "true");
+        if(Boolean.parseBoolean(excludeMapper)) {
+            interfaze.addImportedType(new FullyQualifiedJavaType(
+                    "org.apache.ibatis.annotations.Mapper"));
+            interfaze.addAnnotation("@Mapper");
+        }
         return true;
     }
 


### PR DESCRIPTION
Sometimes I don't need @Mapper annotation, so I add a configuration called mapper to decide if I need to add @Mapper annotations.